### PR TITLE
Remove broken link from POD

### DIFF
--- a/lib/Object/InsideOut.pod
+++ b/lib/Object/InsideOut.pod
@@ -3577,7 +3577,6 @@ Code repository:
 L<https://github.com/jdhedden/Object-InsideOut>
 
 Inside-out Object Model:
-L<http://www.perlfoundation.org/perl5/index.cgi?inside_out_object>,
 L<http://www.perlmonks.org/?node_id=219378>,
 L<http://www.perlmonks.org/?node_id=483162>,
 L<http://www.perlmonks.org/?node_id=515650>,


### PR DESCRIPTION
The link to the Perl Foundation page leads to a 404.

I tried searching for the original on the Wayback Machine, but couldn't find it.